### PR TITLE
Fix several problems in OpenHardwareMonitor plugin

### DIFF
--- a/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/HardwareMonitorActivationRequirement.cs
+++ b/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/HardwareMonitorActivationRequirement.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Artemis.Core.Modules;
+using Serilog;
+
+namespace Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor
+{
+    public class HardwareMonitorActivationRequirement : IModuleActivationRequirement
+    {
+        public string Scope { get; private set; }
+
+        private bool _cached = false;
+        private ProcessActivationRequirement _inner;
+
+        public HardwareMonitorActivationRequirement(string scope, string? processName, string? location = null) {
+            Scope = scope;
+
+            _inner = new ProcessActivationRequirement(processName, location);
+        }
+
+        public bool Evaluate()
+        {
+            if (!_inner.Evaluate())
+            {
+                _cached = false;
+                return false;
+            }
+
+            if (_cached)
+                return true;
+
+            try
+            {
+                using (var updater = new WmiUpdater(Scope)) 
+                {
+                    var sensors = updater.FetchSensors();
+                    var hardwares = updater.FetchHardwares();
+
+                    _cached = hardwares.Count != 0 && sensors.Count != 0;
+
+                    return _cached;
+                }
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+        }
+
+        public string GetUserFriendlyDescription()
+        {
+            return _inner.GetUserFriendlyDescription() + $" and the WMI namespace \"{Scope}\" has some data";
+        }
+    }
+}

--- a/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/Sensor.cs
+++ b/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/Sensor.cs
@@ -16,6 +16,12 @@ namespace Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor
 
         public static Sensor FromManagementObject(ManagementBaseObject obj)
         {
+            SensorType sensorType;
+            if (!Enum.TryParse<SensorType>((string)obj[nameof(SensorType)], out sensorType))
+            {
+                sensorType = SensorType.Other;
+            }
+
             return new Sensor
             {
                 Identifier = (string)obj[nameof(Identifier)],
@@ -24,7 +30,7 @@ namespace Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor
                 Value = (float)obj[nameof(Value)],
                 Name = (string)obj[nameof(Name)],
                 Parent = (string)obj[nameof(Parent)],
-                SensorType = Enum.Parse<SensorType>((string)obj[nameof(SensorType)])
+                SensorType = sensorType
             };
         }
 
@@ -93,6 +99,8 @@ namespace Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor
         Throughput, // B/s
         TimeSpan, // Seconds 
         Energy, // milliwatt-hour (mWh)
-        Noise // dBA
+        Noise, // dBA
+        Conductivity, // µS/cm
+        Other
     }
 }

--- a/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/WmiUpdater.cs
+++ b/src/Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor/WmiUpdater.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Management;
+
+namespace Artemis.Plugins.HardwareMonitors.OpenHardwareMonitor
+{
+    public class WmiUpdater : IDisposable
+    {
+        private static readonly ObjectQuery SensorQuery = new ObjectQuery("SELECT * FROM Sensor");
+        private static readonly ObjectQuery HardwareQuery = new ObjectQuery("SELECT * FROM Hardware");
+
+        private ManagementScope _scope;
+        private ManagementObjectSearcher _sensorSearcher;
+        private ManagementObjectSearcher _hardwareSearcher;
+
+        public WmiUpdater(string scope)
+        {
+            _scope = new ManagementScope(scope, null);
+            _scope.Connect();
+
+            _sensorSearcher = new ManagementObjectSearcher(_scope, SensorQuery);
+            _hardwareSearcher = new ManagementObjectSearcher(_scope, HardwareQuery);
+        }
+
+        public void Dispose()
+        {
+            _sensorSearcher.Dispose();
+            _sensorSearcher = null;
+
+            _hardwareSearcher.Dispose();
+            _hardwareSearcher = null;
+
+            _scope = null;
+        }
+
+        public List<Sensor> FetchSensors()
+        {
+            return Sensor.FromCollection(_sensorSearcher.Get());
+        }
+
+        public List<Hardware> FetchHardwares()
+        {
+            return Hardware.FromCollection(_hardwareSearcher.Get());
+        }
+    }
+}


### PR DESCRIPTION
I faced several problems when using the OpenHardwareMonitor plugin in my environment. I've implemented several fixed for all problems I have noticed:
- `SensorType` was missing the `Conductivity` variant.
- Better use `Enum.TryParse` to parse the `SensorType`, every unknown variant now defaults to `Other`.
- Fetch the WMI to check if the classes have been initialized correctly instead of using `Thread.Sleep`.